### PR TITLE
refactor: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [readme-zh-hans]: https://github.com/akiirui/mpv-handler/blob/main/README.zh-Hans.md
 [readme-zh-hant]: https://github.com/akiirui/mpv-handler/blob/main/README.zh-Hant.md
 
-# MPV handler
+# mpv handler
 
-A protocol handler for **MPV**, written by Rust.
+A protocol handler for **mpv**, written by Rust.
 
-Use **MPV** and **yt-dlp** to play video and music from the websites.
+Use **mpv** and **yt-dlp** to play video and music from the websites.
 
 Please use it with userscript:
 
@@ -20,7 +20,7 @@ Please use it with userscript:
 
 ### Plugins
 
-- `play`: Use MPV player to play video
+- `play`: Use mpv player to play video
 
 ### Encode Video URL
 
@@ -71,14 +71,14 @@ Windows users need to install `mpv-handler` manually.
 #### Manual installation
 
 1. Download [latest/mpv-handler-windows-x64.zip][download-windows]
-2. Unzip the archive to the directory you want (since v0.2.x, not requires to install in the same directory with MPV anymore)
+2. Unzip the archive to the directory you want
 3. Run `handler-install.bat` register protocol handler
-4. Add **MPV** and **yt-dlp** to environment variable `PATH` (if needed)
+4. Add **mpv** and **yt-dlp** to environment variable `PATH` (if needed)
 5. Edit `config.toml` (if needed)
 
 ## Configuration
 
-If you have already added **MPV** and **yt-dlp** to `PATH`, manual configuration is usually not required.
+If you have already added **mpv** and **yt-dlp** to `PATH`, manual configuration is usually not required.
 
 ```toml
 mpv = "/usr/bin/mpv"

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -4,11 +4,11 @@
 [readme-zh-hans]: https://github.com/akiirui/mpv-handler/blob/main/README.zh-Hans.md
 [readme-zh-hant]: https://github.com/akiirui/mpv-handler/blob/main/README.zh-Hant.md
 
-# MPV handler
+# mpv handler
 
-一个 **MPV** 的协议处理程序，使用 Rust 编写。
+一个 **mpv** 的协议处理程序，使用 Rust 编写。
 
-使用 **MPV** 和 **yt-dlp** 播放网站上的视频与音乐。
+使用 **mpv** 和 **yt-dlp** 播放网站上的视频与音乐。
 
 请配合用户脚本使用：
 
@@ -20,7 +20,7 @@
 
 ### 插件 / Plugins
 
-- `play`: 使用 MPV 播放视频
+- `play`: 使用 mpv 播放视频
 
 ### 编码的视频网址 / Encoded Video URL
 
@@ -71,20 +71,20 @@ Windows 用户目前只能手动安装 `mpv-handler`。
 #### 手动安装
 
 1. 下载 [latest/mpv-handler-windows-x64.zip][download-windows]
-2. 解压缩档案到你想要的文件夹里（从 `v0.2.x` 起，不再需要和 MPV 安装至同一个文件夹）
+2. 解压缩档案到你想要的位置
 3. 运行 `handler-install.bat` 注册协议处理程序
-4. 添加 **MPV** 和 **yt-dlp** 到环境变量 `PATH`
+4. 添加 **mpv** 和 **yt-dlp** 到环境变量 `PATH`
 5. 如果需要，更改 `config.toml`
 
 ## 配置
 
-如果您已经把 **MPV** 和 **yt-dlp** 添加到了 `PATH`，通常来说不需要手动配置。
+如果您已经把 **mpv** 和 **yt-dlp** 添加到了 `PATH`，通常来说不需要手动配置。
 
 ```toml
 mpv = "/usr/bin/mpv"
 
 # 可选，类型：字符串
-# MPV 可执行文件的路径
+# mpv 可执行文件的路径
 # 默认值:
 # - Linux: mpv
 # - Windows: mpv.com

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -4,11 +4,11 @@
 [readme-zh-hans]: https://github.com/akiirui/mpv-handler/blob/main/README.zh-Hans.md
 [readme-zh-hant]: https://github.com/akiirui/mpv-handler/blob/main/README.zh-Hant.md
 
-# MPV handler
+# mpv handler
 
-一個 **MPV** 的協議處理程序，使用 Rust 編寫。
+一個 **mpv** 的協議處理程序，使用 Rust 編寫。
 
-使用 **MPV** 和 **yt-dlp** 播放網站上的視頻與音樂。
+使用 **mpv** 和 **yt-dlp** 播放網站上的視頻與音樂。
 
 請配合用戶腳本使用：
 
@@ -20,7 +20,7 @@
 
 ### 插件 / Plugins
 
-- `play`: 使用 MPV 播放視頻
+- `play`: 使用 mpv 播放視頻
 
 ### 編碼的視頻網址 / Encoded Video URL
 
@@ -71,20 +71,20 @@ Windows 用戶目前只能手動安裝 `mpv-handler`。
 #### 手動安裝
 
 1. 下載 [latest/mpv-handler-windows-x64.zip][download-windows]
-2. 解壓縮檔案到你想要的文件夾裏（從 `v0.2.x` 起，不再需要和 MPV 安裝至同一個文件夾）
+2. 解壓縮檔案到你想要的位置
 3. 運行 `handler-install.bat` 註冊協議處理程序
-4. 添加 **MPV** 和 **yt-dlp** 到環境變量 `PATH`
+4. 添加 **mpv** 和 **yt-dlp** 到環境變量 `PATH`
 5. 如果需要，更改 `config.toml`
 
 ## 配置
 
-如果您已經把 **MPV** 和 **yt-dlp** 添加到了 `PATH`，通常來說不需要手動配置。
+如果您已經把 **mpv** 和 **yt-dlp** 添加到了 `PATH`，通常來說不需要手動配置。
 
 ```toml
 mpv = "/usr/bin/mpv"
 
 # 可選，類型：字符串
-# MPV 可執行文件的路徑
+# mpv 可執行文件的路徑
 # 默認值:
 # - Linux: mpv
 # - Windows: mpv.com

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 /// Config of mpv-handler
 ///
-/// - `mpv`: MPV player binary path
+/// - `mpv`: mpv player binary path
 /// - `ytdl`: Youtube-DL binary path
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/src/plugins/play.rs
+++ b/src/plugins/play.rs
@@ -62,14 +62,14 @@ pub fn exec(proto: &Protocol, config: &Config) -> Result<(), Error> {
     };
 
     // Fix some browsers to overwrite "LD_LIBRARY_PATH" on Linux
-    // It will be broken MPV player
+    // It will be broken mpv player
     // mpv: symbol lookup error: mpv: undefined symbol: vkCreateWaylandSurfaceKHR
     #[cfg(unix)]
     std::env::remove_var("LD_LIBRARY_PATH");
 
     println!("Playing: {}", proto.url);
 
-    // Execute MPV player
+    // Execute mpv player
     let player = std::process::Command::new(&config.mpv)
         .args(options)
         .arg("--")


### PR DESCRIPTION
Lowercase "mpv" is official name of mpv player.

So, replace all "MPV" to "mpv".