### PR TITLE
fix: don't exit if the cookies file doesn't exist

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,8 +13,6 @@ pub enum Error {
     #[cfg(unix)]
     #[error("Failed to get config directory")]
     FailedGetConfigDir,
-    #[error("Cookies file \"{0}\" doesn't exist")]
-    CookiesFileNotFound(String),
     #[error("Player exited by error")]
     PlayerExited(u8),
     #[error("Failed to run player. {0}")]


### PR DESCRIPTION
Update the quality parse method, Now accepts any resolution number, by trim all letters from the value.