### PR TITLE
feat: support custom player window title

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "serde",
  "thiserror",
  "toml",
+ "urlencoding",
 ]
 
 [[package]]
@@ -241,6 +242,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ dirs = "5.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 toml = "0.8"
+urlencoding = "2.1.3"
 
 [features]
 console = []

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ profile = [ default, low-latency, etc... ]
 quality = [ 2160p, 1440p, 1080p, 720p, 480p, 360p ]
 v_codec = [ av01, vp9, h265, h264 ]
 subfile = [ Encoded URL ]
+title = [ Player Window Title, encoded with JavaScript fucntion `encodeURIComponent()` ]
 ```
 
 ## Installation

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -48,6 +48,7 @@ profile = [ default, low-latency, etc... ]
 quality = [ 2160p, 1440p, 1080p, 720p, 480p, 360p ]
 v_codec = [ av01, vp9, h265, h264 ]
 subfile = [ Encoded URL ]
+title = [ Player Window Title, encoded with JavaScript fucntion `encodeURIComponent()` ]
 ```
 
 ## 安装

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -48,6 +48,7 @@ profile = [ default, low-latency, etc... ]
 quality = [ 2160p, 1440p, 1080p, 720p, 480p, 360p ]
 v_codec = [ av01, vp9, h265, h264 ]
 subfile = [ Encoded URL ]
+title = [ Player Window Title, encoded with JavaScript fucntion `encodeURIComponent()` ]
 ```
 
 ## 安裝

--- a/src/plugins/play.rs
+++ b/src/plugins/play.rs
@@ -53,7 +53,7 @@ pub fn exec(proto: &Protocol, config: &Config) -> Result<(), Error> {
         options.push(&option_yt_path);
     }
 
-    // Set custom title
+    // Set custom mpv title
     if let Some(v) = &proto.title {
         option_title = title(v);
         options.push(&option_title);
@@ -159,7 +159,7 @@ fn yt_path(yt_path: &str) -> String {
     format!("{PREFIX_YT_PATH}{yt_path}")
 }
 
-/// Return video title
+/// Return mpv title option
 fn title(title: &str) -> String {
     format!("{PREFIX_TITLE}{title}")
 }

--- a/src/plugins/play.rs
+++ b/src/plugins/play.rs
@@ -7,6 +7,7 @@ const PREFIX_PROFILE: &str = "--profile=";
 const PREFIX_FORMATS: &str = "--ytdl-raw-options-append=format-sort=";
 const PREFIX_SUBFILE: &str = "--sub-file=";
 const PREFIX_YT_PATH: &str = "--script-opts=ytdl_hook-ytdl_path=";
+const PREFIX_TITLE: &str = "--title=";
 
 /// Execute player with given options
 pub fn exec(proto: &Protocol, config: &Config) -> Result<(), Error> {
@@ -16,6 +17,7 @@ pub fn exec(proto: &Protocol, config: &Config) -> Result<(), Error> {
     let option_formats: String;
     let option_subfile: String;
     let option_yt_path: String;
+    let option_title: String;
 
     // Append cookies option
     if let Some(v) = proto.cookies {
@@ -49,6 +51,12 @@ pub fn exec(proto: &Protocol, config: &Config) -> Result<(), Error> {
     if let Some(v) = &config.ytdl {
         option_yt_path = yt_path(v);
         options.push(&option_yt_path);
+    }
+
+    // Set custom title
+    if let Some(v) = &proto.title {
+        option_title = title(v);
+        options.push(&option_title);
     }
 
     // Set HTTP(S) proxy environment variables
@@ -151,6 +159,11 @@ fn yt_path(yt_path: &str) -> String {
     format!("{PREFIX_YT_PATH}{yt_path}")
 }
 
+/// Return video title
+fn title(title: &str) -> String {
+    format!("{PREFIX_TITLE}{title}")
+}
+
 #[test]
 fn test_profile_option() {
     let p = profile("low-latency");
@@ -182,4 +195,10 @@ fn test_subfile_option() {
 fn test_yt_path_option() {
     let y = yt_path("/usr/bin/yt-dlp");
     assert_eq!(y, format!("{PREFIX_YT_PATH}/usr/bin/yt-dlp"));
+}
+
+#[test]
+fn test_title_option() {
+    let t = title("My custom title");
+    assert_eq!(t, format!("{PREFIX_TITLE}My custom title"));
 }


### PR DESCRIPTION
close #62

Implement the custom player window title feature

## Usage

The `title` parameter needs to be encoded with the JavaScript function `encodeURIComponent()`

```js
let title = encodeURIComponent('Hello world');
```

Then pass the `title` parameter:

```bash
mpv://play/aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g_dj1HZ2tuMmY1ZS1JVQ/?title=Hello%20world
```